### PR TITLE
Publish percentages of used resources.

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ const (
 	DEFAULT_CPU_AGGR        = false                                                              // Default whether to only report aggregate CPU
 	DEFAULT_SYSLOGNG_SOCKET = "/var/lib/syslog-ng/syslog-ng.ctl"                                 // Default location of the syslog-ng socket
 	DEFAULT_SOCKSTAT_PROTOS = "TCP,UDP,TCP6,UDP6"                                                // Default protocols to report sockstats on
+	DEFAULT_PERCENTAGES     = ""                                                                 // Default pollers where publishing perc metrics is allowed
 )
 
 var (
@@ -29,6 +30,7 @@ type Config struct {
 	Source              string
 	Prefix              string
 	ProfilePort         string
+	Percentages         []string
 	DfTypes             []string
 	Listen              string
 	NifDevices          []string
@@ -54,6 +56,7 @@ func GetConfig() (config Config) {
 	config.Source = GetEnvWithDefault("SHH_SOURCE", "")                                                      // Source to emit
 	config.Prefix = GetEnvWithDefault("SHH_PREFIX", "")                                                      // Metric prefix to use
 	config.ProfilePort = GetEnvWithDefault("SHH_PROFILE_PORT", DEFAULT_PROFILE_PORT)                         // Profile Port
+	config.Percentages = GetEnvWithDefaultStrings("SHH_PERCENTAGES", DEFAULT_PERCENTAGES)
 	config.DfTypes = GetEnvWithDefaultStrings("SHH_DF_TYPES", DEFAULT_DF_TYPES)                              // Default DF types
 	config.Listen = GetEnvWithDefault("SHH_LISTEN", "unix,#shh")                                             // Default network socket info for listen
 	config.NifDevices = GetEnvWithDefaultStrings("SHH_NIF_DEVICES", DEFAULT_NIF_DEVICES)                     // Devices to poll

--- a/mem_poller.go
+++ b/mem_poller.go
@@ -10,14 +10,22 @@ const (
 
 type Memory struct {
 	measurements chan<- *Measurement
+	memPercentage bool
+	swapPercentage bool
 }
 
-func NewMemoryPoller(measurements chan<- *Measurement) Memory {
-	return Memory{measurements: measurements}
+func NewMemoryPoller(measurements chan<- *Measurement, config Config) Memory {
+	memPerc := LinearSliceContainsString(config.Percentages, "mem")
+	swapPerc := LinearSliceContainsString(config.Percentages, "swap")
+	return Memory{measurements: measurements, memPercentage: memPerc, swapPercentage: swapPerc}
 }
 
 // http://www.kernel.org/doc/Documentation/filesystems/proc.txt
 func (poller Memory) Poll(tick time.Time) {
+	memTotal := float64(-1)
+	memFree := float64(-1)
+	swapTotal := float64(-1)
+	swapFree := float64(-1)
 
 	for line := range FileLineChannel(MEMORY_FILE) {
 		fields := Fields(line)
@@ -27,6 +35,27 @@ func (poller Memory) Poll(tick time.Time) {
 			value = value * 1024.0
 		}
 		poller.measurements <- &Measurement{tick, poller.Name(), fixed_names, value}
+
+		switch fixed_names[0] {
+		case "memtotal":
+			memTotal = value
+		case "memfree":
+			memFree = value
+		case "swaptotal":
+			swapTotal = value
+		case "swapfree":
+			swapFree = value
+		}
+	}
+
+	if poller.memPercentage && memTotal > 0.0 && memFree >= 0.0 {
+		poller.measurements <- &Measurement{tick, poller.Name(),
+			[]string{"memtotal", "perc"}, (memTotal - memFree) / memTotal}
+	}
+
+	if poller.swapPercentage && swapTotal > 0.0 && swapFree >= 0.0 {
+		poller.measurements <- &Measurement{tick, poller.Name(),
+			[]string{"swaptotal", "perc"}, (swapTotal - swapFree) / swapTotal}
 	}
 }
 

--- a/pollers.go
+++ b/pollers.go
@@ -27,7 +27,7 @@ func NewMultiPoller(measurements chan<- *Measurement, config Config) Multi {
 		case "listen":
 			mp.RegisterPoller(NewListenPoller(measurements, config))
 		case "mem":
-			mp.RegisterPoller(NewMemoryPoller(measurements))
+			mp.RegisterPoller(NewMemoryPoller(measurements, config))
 		case "nif":
 			mp.RegisterPoller(NewNetworkInterfacePoller(measurements, config))
 		case "ntpdate":


### PR DESCRIPTION
Configured via new env var, SHH_PERCENTAGES, a comma separated list:
- df: If poller df is on, publish total used as percentage for each
   filesystem that is reported
- mem: if poller mem is on, publish total memory in use as percentage
- swap: if poller mem is on, publish total swap in use as percentage.
