### PR TITLE
SHH_LIBRATO_ROUND: Round times to the nearest interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configuration of shh doesn't use a config file, instead it uses environment vari
 | `SHH_LIBRATO_BATCH_SIZE` | int | The max number of metrics to submit in a single request | 500 |
 | `SHH_LIBRATO_BATCH_TIMEOUT` | duration | The max time metrics will sit un-delivered | `SHH_INTERVAL` |
 | `SHH_LIBRATO_NETWORK_TIMEOUT` | duration | Timeout til connect (will retry). And timeout to first header (will assume successful) | 5s |
+| `SHH_LIBRATO_ROUND` | bool | Should shh round times to the nearest interval? | true |
 | `SHH_CARBON_HOST` | string | Where the Carbon Outputter sends it's data | |
 | `SHH_SOCKSTAT_PROTOS` | list of string | Protocols to report sockstats about | TCP,UDP,TCP6,UDP6 |
 | `SHH_STATSD_HOST` | string | Where the Statsd Outputter sends it's data | |

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ const (
 	DEFAULT_LIBRATO_BATCH_SIZE      = 500
 	DEFAULT_LIBRATO_NETWORK_TIMEOUT = "5s"
 	DEFAULT_LIBRATO_BATCH_TIMEOUT   = "10s"
+	DEFAULT_LIBRATO_ROUND           = true
 	DEFAULT_LISTEN_ADDR             = "unix,#shh"
 	DEFAULT_DISK_FILTER             = "(xv|s)d"
 )
@@ -58,6 +59,7 @@ type Config struct {
 	LibratoBatchSize      int
 	LibratoBatchTimeout   time.Duration
 	LibratoNetworkTimeout time.Duration
+	LibratoRound          bool
 	CarbonHost            string
 	SockStatProtos        []string
 	StatsdHost            string
@@ -90,6 +92,7 @@ func GetConfig() (config Config) {
 	config.LibratoBatchSize = GetEnvWithDefaultInt("SHH_LIBRATO_BATCH_SIZE", DEFAULT_LIBRATO_BATCH_SIZE)                     // The max number of metrics to submit in a single request
 	config.LibratoBatchTimeout = GetEnvWithDefaultDuration("SHH_LIBRATO_BATCH_TIMEOUT", DEFAULT_LIBRATO_BATCH_TIMEOUT)       // The max time metrics will sit un-delivered
 	config.LibratoNetworkTimeout = GetEnvWithDefaultDuration("SHH_LIBRATO_NETWORK_TIMEOUT", DEFAULT_LIBRATO_NETWORK_TIMEOUT) // The maximum time to wait for Librato to respond (for both dial and first header)
+	config.LibratoRound = GetEnvWithDefaultBool("SHH_LIBRATO_ROUND", DEFAULT_LIBRATO_ROUND)                                  // Should we round measurement times to the nearest Interval when submitting to Librato
 	config.CarbonHost = GetEnvWithDefault("SHH_CARBON_HOST", DEFAULT_EMPTY_STRING)                                           // Where the Carbon Outputter sends it's data
 	config.SockStatProtos = GetEnvWithDefaultStrings("SHH_SOCKSTAT_PROTOS", DEFAULT_SOCKSTAT_PROTOS)                         // Protocols to report sockstats about
 	config.StatsdHost = GetEnvWithDefault("SHH_STATSD_HOST", DEFAULT_EMPTY_STRING)                                           // Where the Statsd Outputter sends it's data


### PR DESCRIPTION
Default: true

w/o this you need to use composite functions to get data to "line up" on
interval boundaries in the UI. Composite functions require more work for
the user and are _currently_ slower to gather than normal metrics.
