### PR TITLE
I'm not sure what's going on here....

### DIFF
--- a/cmd/shh/main.go
+++ b/cmd/shh/main.go
@@ -37,8 +37,10 @@ func main() {
 
 	go func() {
 		for sig := range signalChannel {
+			now := time.Now()
+			shh.ErrLogger.Println(slog.Context{"signal": sig, "finishing": now, "runtime": time.Since(config.Start)})
 			mp.Exit()
-			shh.ErrLogger.Fatal(slog.Context{"signal": sig, "finished": time.Now(), "duration": time.Since(config.Start)})
+			shh.ErrLogger.Fatalln(slog.Context{"signal": sig, "finished": time.Now(), "duration": time.Since(now)})
 		}
 	}()
 


### PR DESCRIPTION
We're seeing things like this though ...

```
2014-11-11T23:41:50.615207+00:00 54.82.58.235 local2.info shh[1973]: -
runtime-dedicated.214537@heroku.com shh: 2014/11/11 23:41:50
interval=60.000 start

runtime-dedicated.214537@heroku.com shh: 2014/11/11 23:47:20
error="accept unix #shh: use of closed network connection"
fn=NewListenPoller message="accepting connection" poller=listen

Repeats ~ 200 times

2014-11-11T23:47:20.991774+00:00 54.82.58.235 local2.err shh[1973]: -
runtime-dedicated.214537@heroku.com shh: 2014/11/11 23:47:20 error="use
of closed network connection" fn=NewListenPoller message="accepting
connection" poller=listen

2014-11-11T23:47:21.714906+00:00 54.82.58.235 local2.err shh[1973]: -
runtime-dedicated.214537@heroku.com shh: 2014/11/11 23:47:21
duration=330.231 finished="2014-11-11T23:47:20.833347927Z"
signal=terminated

2014-11-11T23:47:23.952790+00:00 54.82.58.235 local2.info shh[7730]: -
runtime-dedicated.214537@heroku.com shh: 2014/11/11 23:47:23
interval=60.000 start
```

So my assumption is that we're getting the signal, which ends up
closing the listener, which generated a bunch of errors sicne we're in
a tight loop in the listen poller and we spit out a bunch of these
until we actually exit.

This should reduce these (although I don't think it will eliminate
them).

/cc @apg 
