### PR TITLE
make it work with stock folsom_cowboy

### DIFF
--- a/folsom_poller.go
+++ b/folsom_poller.go
@@ -59,13 +59,13 @@ type FolsomWallClock struct {
 	SinceLast uint64 `json:"wall_clock_time_since_last_call"`
 }
 
-type FolsomMetrics struct {
-	Metrics []string `json:""`
+type FolsomType struct {
+	Type string `json:"type"`
 }
 
 type FolsomValue struct {
 	Name  string
-	Type  string      `json:"type"`
+	Type  string
 	Value json.Number `json:"value"`
 }
 
@@ -148,14 +148,14 @@ func (poller FolsomPoller) doStatisticsPoll(ctx slog.Context, tick time.Time) {
 }
 
 func (poller FolsomPoller) doMetricsPoll(ctx slog.Context, tick time.Time) {
-	keys := []string{}
-	if err := poller.decodeReq("/_metrics", &keys); err != nil {
+	metrics := make(map[string]FolsomType)
+	if err := poller.decodeReq("/_metrics?info=true", &metrics); err != nil {
 		LogError(ctx, err, "while performing request for this tick")
 		return
 	}
 
-	for i := range keys {
-		v := FolsomValue{Name: keys[i]}
+	for key, ft := range metrics {
+		v := FolsomValue{Name: key, Type: ft.Type}
 		if err := poller.decodeReq("/_metrics/"+v.Name, &v); err != nil {
 			LogError(ctx, err, "while performing request for "+v.Name+"this tick")
 			return


### PR DESCRIPTION
Browsing through the source code for the metrics handler I found that you can pass `?info=true` and have folsom_cowboy return all the various types for metrics, making my `folsom_cowboy` fork redundant.
