### PR TITLE
Ets memory in words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.9.6 - 2015-01-06
+## 0.9.7 - 2015-01-05
+
+### Changed
+
+- Fixed ETS table memory to report in words not bytes.
+
+## 0.9.6 - 2015-01-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.9.7 - 2015-01-05
+## 0.9.8 - 2015-01-05
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Fixed ETS table memory to report in words not bytes.
+- Bugfix: ETS table memory to report in words not bytes.
 
 ## 0.9.7 - 2015-01-05
 

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	VERSION                          = "0.9.7"
+	VERSION                          = "0.9.8"
 	DEFAULT_EMPTY_STRING             = ""
 	DEFAULT_INTERVAL                 = "60s"                                                              // Default tick interval for pollers
 	DEFAULT_OUTPUTTER                = "stdoutl2metder"                                                   // Default outputter

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	VERSION                          = "0.9.6"
+	VERSION                          = "0.9.7"
 	DEFAULT_EMPTY_STRING             = ""
 	DEFAULT_INTERVAL                 = "60s"                                                              // Default tick interval for pollers
 	DEFAULT_OUTPUTTER                = "stdoutl2metder"                                                   // Default outputter

--- a/folsom_poller.go
+++ b/folsom_poller.go
@@ -170,7 +170,7 @@ func (poller FolsomPoller) doEtsPoll(ctx slog.Context, tick time.Time) {
 	}
 
 	for _, tab := range tables {
-		poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"ets", tab.Name, "memory"}, tab.Memory, Bytes}
+		poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"ets", tab.Name, "memory"}, tab.Memory, Words}
 		poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"ets", tab.Name, "size"}, tab.Size, Terms}
 	}
 }


### PR DESCRIPTION
Folsom simply dumps the results of doing an ets:info call on the various ets tables. This call reports the memory used in words not bytes.