### PR TITLE
Make it possible to turn metadata off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.4.1
+- 1.4.2
 script:
 - make test
 before_deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- SHH_VERBOSE: On by default, this turns on meta data reporting, currently
-  reported in the Librato outputter (number of guages, counters), the multi
-  poller's stats, and the listen poller's meta data.
-- SHH_POLLER_BLACKLIST: Removes listed pollers from the Pollers list.
+- SHH_META: Off by default. This controls meta stats collection and
+  reporting. Turn this on to get:
+
+  - Librato stats (number of gauges, number of counters)
+  - multi poller's stats
+  - listen poller's meta stats
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.9.9 - 2015-03-06
+
+### Added
+
+- SHH_VERBOSE: On by default, this turns on meta data reporting, currently
+  reported in the Librato outputter (number of guages, counters), the multi
+  poller's stats, and the listen poller's meta data.
+- SHH_POLLER_BLACKLIST: Removes listed pollers from the Pollers list.
+
+### Removed
+
+- Removed `lo` from the default NIF_DEVICES
+- pid.last from the load poller. This is useless on a time series plot.
+
 ## 0.9.8 - 2015-01-05
 
 ### Changed

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/heroku/shh",
-	"GoVersion": "go1.4.1",
+	"GoVersion": "go1.4.2",
 	"Packages": [
 		"./..."
 	],

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Configuration of shh doesn't use a config file, instead it uses environment vari
 | Environment Var | Type | Explanation | Default |
 |:----------------|:-----|:------------|:--------|
 | `SHH_INTERVAL` | duration | Polling Interval | 10s |
+| `SHH_VERBOSE` | bool | Report meta metrics | false |
 | `SHH_OUTPUTTER` | string | Outputter | stdoutl2metder |
 | `SHH_POLLERS` | list of string | Pollers to poll | conntrack,cpu,df,disk,listen,load,mem,nif,ntpdate,processes,self |
+| `SHH_POLLER_BLACKLIST` | list of string | Pollers to blacklist | conntrack,cpu,df,disk,listen,load,mem,nif,ntpdate,processes,self |
 | `SHH_SOURCE` | string | Source to emit | |
 | `SHH_PREFIX` | string | Metric prefix to use | |
 | `SHH_PROFILE_PORT` | string | Profile Port | 0 (off) |

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ Configuration of shh doesn't use a config file, instead it uses environment vari
 | Environment Var | Type | Explanation | Default |
 |:----------------|:-----|:------------|:--------|
 | `SHH_INTERVAL` | duration | Polling Interval | 10s |
-| `SHH_VERBOSE` | bool | Report meta metrics | false |
+| `SHH_META` | bool | Report/Collect meta stats | false |
 | `SHH_OUTPUTTER` | string | Outputter | stdoutl2metder |
 | `SHH_POLLERS` | list of string | Pollers to poll | conntrack,cpu,df,disk,listen,load,mem,nif,ntpdate,processes,self |
-| `SHH_POLLER_BLACKLIST` | list of string | Pollers to blacklist | conntrack,cpu,df,disk,listen,load,mem,nif,ntpdate,processes,self |
 | `SHH_SOURCE` | string | Source to emit | |
 | `SHH_PREFIX` | string | Metric prefix to use | |
 | `SHH_PROFILE_PORT` | string | Profile Port | 0 (off) |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Configuration of shh doesn't use a config file, instead it uses environment vari
 | `SHH_DF_TYPES` | list of string | Default DF types | btrfs,ext3,ext4,tmpfs,xfs |
 | `SHH_LISTEN` | string | Default network socket info for listen | unix,#shh |
 | `SHH_LISTEN_TIMEOUT` | string | Socket timeout duration | `SHH_INTERVAL` |
-| `SHH_NIF_DEVICES` | list of string | Devices to poll | eth0,lo |
+| `SHH_NIF_DEVICES` | list of string | Devices to poll | eth0 |
 | `SHH_NTPDATE_SERVERS` | list of string | NTP Servers | 0.pool.ntp.org,1.pool.ntp.org |
 | `SHH_CPU_AGGR` | bool | Whether to only report aggregate CPU usage | true |
 | `SHH_LIBRATO_USER` | string | The Librato API User | |

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ const (
 	DEFAULT_NETWORK_TIMEOUT          = "5s"
 	DEFAULT_REDIS_INFO               = "clients:connected_clients;memory:used_memory,used_memory_rss;stats:instantaneous_ops_per_sec;keyspace:db0.keys" // semi colon seperated section:keya,keyb list
 	DEFAULT_REDIS_URL                = "tcp://localhost:6379/0?timeout=10s&maxidle=1"
-	DEFAULT_VERBOSE                  = true
+	DEFAULT_META                     = false
 )
 
 var (
@@ -50,7 +50,6 @@ type Config struct {
 	Interval              time.Duration
 	Outputter             string
 	Pollers               []string
-	PollerBlacklist       []string
 	Source                string
 	Prefix                string
 	ProfilePort           string
@@ -87,14 +86,13 @@ type Config struct {
 	FolsomBaseUrl         *url.URL
 	RedisUrl              *url.URL
 	RedisInfo             string
-	Verbose               bool
+	Meta                  bool
 }
 
 func GetConfig() (config Config) {
 	config.Interval = GetEnvWithDefaultDuration("SHH_INTERVAL", DEFAULT_INTERVAL)                                          // Polling Interval
 	config.Outputter = GetEnvWithDefault("SHH_OUTPUTTER", DEFAULT_OUTPUTTER)                                               // Outputter
 	config.Pollers = GetEnvWithDefaultStrings("SHH_POLLERS", DEFAULT_POLLERS)                                              // Pollers to poll
-	config.PollerBlacklist = GetEnvWithDefaultStrings("SHH_POLLER_BLACKLIST", "")                                          // Pollers that should never be enabled, even if they appear in Pollers. Pollers essentially becomes Pollers - PollerBlacklist
 	config.Source = GetEnvWithDefault("SHH_SOURCE", DEFAULT_EMPTY_STRING)                                                  // Source to emit
 	config.Prefix = GetEnvWithDefault("SHH_PREFIX", DEFAULT_EMPTY_STRING)                                                  // Metric prefix to use
 	config.ProfilePort = GetEnvWithDefault("SHH_PROFILE_PORT", DEFAULT_PROFILE_PORT)                                       // Profile Port
@@ -128,7 +126,7 @@ func GetConfig() (config Config) {
 	config.RedisUrl = GetEnvWithDefaultURL("SHH_REDIS_URL", DEFAULT_REDIS_URL)                                             // URL of redis endpoint. Ex: tcp://auth:pass@localhost:6379/0?timeout=10s&maxidle=1"
 	config.RedisInfo = GetEnvWithDefault("SHH_REDIS_INFO", DEFAULT_REDIS_INFO)                                             // section:key1,key2;section2:key1,key2
 	config.NetworkTimeout = GetEnvWithDefaultDuration("NETWORK_TIMEOUT", DEFAULT_NETWORK_TIMEOUT)                          // The maximum time to wait for network requests to respond (for both dial and first header when applicable)
-	config.Verbose = GetEnvWithDefaultBool("SHH_VERBOSE", DEFAULT_VERBOSE)                                                 // Should report meta measurements, such as batch sizes for outputters, etc.
+	config.Meta = GetEnvWithDefaultBool("SHH_META", DEFAULT_META)                                                          // Should report meta measurements, such as batch sizes for outputters, etc.
 
 	tmp := GetEnvWithDefault("SHH_DISK_FILTER", DEFAULT_DISK_FILTER)
 	config.DiskFilter = regexp.MustCompile(tmp)

--- a/librato_output.go
+++ b/librato_output.go
@@ -49,7 +49,7 @@ type Librato struct {
 	userAgent    string
 	interval     time.Duration
 	round        bool
-	verbose      bool
+	meta         bool
 }
 
 func NewLibratoOutputter(measurements <-chan Measurement, config Config) *Librato {
@@ -84,7 +84,7 @@ func NewLibratoOutputter(measurements <-chan Measurement, config Config) *Librat
 		round:        config.LibratoRound,
 		userAgent:    config.UserAgent,
 		client:       &http.Client{Timeout: config.NetworkTimeout},
-		verbose:      config.Verbose,
+		meta:         config.Meta,
 	}
 }
 
@@ -159,7 +159,7 @@ func (out *Librato) deliver() {
 			counters, gauges = out.appendLibratoMetric(counters, gauges, mm)
 		}
 
-		if out.verbose {
+		if out.meta {
 			counters, gauges = out.appendLibratoMetric(
 				counters,
 				gauges,

--- a/librato_output.go
+++ b/librato_output.go
@@ -49,6 +49,7 @@ type Librato struct {
 	userAgent    string
 	interval     time.Duration
 	round        bool
+	verbose      bool
 }
 
 func NewLibratoOutputter(measurements <-chan Measurement, config Config) *Librato {
@@ -83,6 +84,7 @@ func NewLibratoOutputter(measurements <-chan Measurement, config Config) *Librat
 		round:        config.LibratoRound,
 		userAgent:    config.UserAgent,
 		client:       &http.Client{Timeout: config.NetworkTimeout},
+		verbose:      config.Verbose,
 	}
 }
 
@@ -157,16 +159,18 @@ func (out *Librato) deliver() {
 			counters, gauges = out.appendLibratoMetric(counters, gauges, mm)
 		}
 
-		counters, gauges = out.appendLibratoMetric(
-			counters,
-			gauges,
-			GaugeMeasurement{time.Now(), "librato-outlet", []string{"batch", "guage", "size"}, uint64(len(gauges) + 2), Metrics},
-		)
-		counters, gauges = out.appendLibratoMetric(
-			counters,
-			gauges,
-			GaugeMeasurement{time.Now(), "librato-outlet", []string{"batch", "counter", "size"}, uint64(len(counters)), Metrics},
-		)
+		if out.verbose {
+			counters, gauges = out.appendLibratoMetric(
+				counters,
+				gauges,
+				GaugeMeasurement{time.Now(), "librato-outlet", []string{"batch", "guage", "size"}, uint64(len(gauges) + 2), Metrics},
+			)
+			counters, gauges = out.appendLibratoMetric(
+				counters,
+				gauges,
+				GaugeMeasurement{time.Now(), "librato-outlet", []string{"batch", "counter", "size"}, uint64(len(counters)), Metrics},
+			)
+		}
 
 		payload := LibratoPostBody{gauges, counters}
 		j, err := json.Marshal(payload)

--- a/listen_poller.go
+++ b/listen_poller.go
@@ -45,7 +45,7 @@ type Listen struct {
 	metricCount,
 	connectionCount,
 	parseErrorCount uint64
-	verbose   bool
+	meta      bool
 	closeDown chan struct{}
 }
 
@@ -89,7 +89,7 @@ func NewListenPoller(measurements chan<- Measurement, config Config) Listen {
 		listener:     listener,
 		Timeout:      config.ListenTimeout,
 		closeDown:    make(chan struct{}, 1),
-		verbose:      config.Verbose,
+		meta:         config.Meta,
 	}
 
 	go poller.Accept()
@@ -126,7 +126,7 @@ func (poller Listen) Exit() {
 }
 
 func (poller Listen) Poll(tick time.Time) {
-	if poller.verbose {
+	if poller.meta {
 		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "metric", "count"}, poller.metricCount, Empty}
 		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "connection", "count"}, poller.connectionCount, Empty}
 		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "parse", "error", "count"}, poller.parseErrorCount, Empty}

--- a/listen_poller.go
+++ b/listen_poller.go
@@ -45,6 +45,7 @@ type Listen struct {
 	metricCount,
 	connectionCount,
 	parseErrorCount uint64
+	verbose   bool
 	closeDown chan struct{}
 }
 
@@ -88,6 +89,7 @@ func NewListenPoller(measurements chan<- Measurement, config Config) Listen {
 		listener:     listener,
 		Timeout:      config.ListenTimeout,
 		closeDown:    make(chan struct{}, 1),
+		verbose:      config.Verbose,
 	}
 
 	go poller.Accept()
@@ -124,9 +126,11 @@ func (poller Listen) Exit() {
 }
 
 func (poller Listen) Poll(tick time.Time) {
-	poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "metric", "count"}, poller.metricCount, Empty}
-	poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "connection", "count"}, poller.connectionCount, Empty}
-	poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "parse", "error", "count"}, poller.parseErrorCount, Empty}
+	if poller.verbose {
+		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "metric", "count"}, poller.metricCount, Empty}
+		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "connection", "count"}, poller.connectionCount, Empty}
+		poller.measurements <- CounterMeasurement{tick, poller.Name(), []string{"_meta_", "parse", "error", "count"}, poller.parseErrorCount, Empty}
+	}
 }
 
 func (poller *Listen) HandleListenConnection(conn net.Conn) {

--- a/load_poller.go
+++ b/load_poller.go
@@ -44,7 +44,6 @@ func (poller Load) Poll(tick time.Time) {
 	entities := strings.Split(fields[3], "/")
 	poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"scheduling", "entities", "executing"}, Atouint64(entities[0]), Processes}
 	poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"scheduling", "entities", "total"}, Atouint64(entities[1]), Processes}
-	poller.measurements <- GaugeMeasurement{tick, poller.Name(), []string{"pid", "last"}, Atouint64(fields[4]), Empty}
 }
 
 func (poller Load) Name() string {

--- a/pollers.go
+++ b/pollers.go
@@ -12,13 +12,9 @@ type Poller interface {
 }
 
 func NewMultiPoller(measurements chan<- Measurement, config Config) Multi {
-	mp := Multi{pollers: make(map[string]Poller), measurements: measurements, verbose: config.Verbose}
+	mp := Multi{pollers: make(map[string]Poller), measurements: measurements, meta: config.Meta}
 
 	for _, poller := range config.Pollers {
-		if SliceContainsString(config.PollerBlacklist, poller) {
-			continue
-		}
-
 		switch poller {
 		case "load":
 			mp.RegisterPoller(NewLoadPoller(measurements))
@@ -67,7 +63,7 @@ type Multi struct {
 	sync.WaitGroup
 	measurements chan<- Measurement
 	pollers      map[string]Poller
-	verbose      bool
+	meta         bool
 }
 
 func (mp Multi) RegisterPoller(poller Poller) {
@@ -75,7 +71,7 @@ func (mp Multi) RegisterPoller(poller Poller) {
 }
 
 func (mp Multi) durationMetric(tick time.Time, name string, start time.Time) {
-	if mp.verbose {
+	if mp.meta {
 		mp.measurements <- FloatGaugeMeasurement{tick, mp.Name(), []string{"duration", name, "seconds"}, time.Since(start).Seconds(), Seconds}
 	}
 }


### PR DESCRIPTION
  - Remove `lo` from default NIF_DEVICES
  - Ax pid.last from the load poller
  - Add SHH_VERBOSE for metadata
  - Add SHH_POLLER_BLACKLIST.