### PR TITLE
Cgroup poller

### DIFF
--- a/cgroup_poller.go
+++ b/cgroup_poller.go
@@ -47,7 +47,7 @@ func (poller Cgroup) parsePercentCpu(line string, tick time.Time, cgroup string)
 	// absolute number of centiseconds of CPU time used
 	centis := Atouint64(fields[1])
 
-        key := cgroup + "." + metric
+	key := cgroup + "." + metric
 	last, exists := poller.last[key]
 
 	if exists {

--- a/cgroup_poller.go
+++ b/cgroup_poller.go
@@ -1,0 +1,103 @@
+package shh
+
+import (
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/heroku/shh/Godeps/_workspace/src/github.com/freeformz/filechan"
+)
+
+const (
+	CGROUPS_PATH = "/sys/fs/cgroup"
+)
+
+type Cgroup struct {
+	measurements chan<- Measurement
+	last         map[string]uint64
+	cgroups      []string
+	// The kernel will report CPU usage in centiseconds.  This
+	// stores the total centiseconds in the polling interval.
+	totalCentis uint64
+}
+
+func NewCgroupPoller(measurements chan<- Measurement, config Config) Cgroup {
+	println("constructed")
+	return Cgroup{
+		measurements: measurements,
+		last:         make(map[string]uint64),
+		cgroups:      config.Cgroups,
+		// convert the interval to centiseconds
+		totalCentis: uint64(config.Interval.Nanoseconds() / 10000000),
+	}
+}
+
+// parsePercent parses a line from cpuacct.stat like "user 12345678",
+// calculates the delta from the last measurement, calculates the
+// average percentage of one CPU core used, and submits the data point.
+func (poller Cgroup) parsePercentCpu(line string, tick time.Time) {
+	println("cpu " + line)
+
+	fields := strings.Fields(line)
+
+	// "user" or "system"
+	metric := fields[0]
+
+	// absolute number of centiseconds of CPU time used
+	centis := Atouint64(fields[1])
+
+	last, exists := poller.last[metric]
+
+	if exists {
+		delta := centis - last
+		percent := float64(delta) * 100.0 / float64(poller.totalCentis)
+
+		poller.measurements <- FloatGaugeMeasurement{tick, poller.Name(), []string{"cpu", metric}, percent, Percent}
+	}
+
+	poller.last[metric] = centis
+}
+
+func (poller Cgroup) parseMaxMemory(cgroup string, metric string, fileName string, tick time.Time) {
+	println("memory " + metric)
+
+	path := CGROUPS_PATH + "/memory/" + cgroup + "/" + fileName
+	data, err := ioutil.ReadFile(path)
+
+	if err == nil {
+		maxBytes := Atofloat64(strings.TrimSpace(string(data)))
+		poller.measurements <- FloatGaugeMeasurement{tick, poller.Name(), []string{"mem", metric}, maxBytes, Bytes}
+
+		// reset the high water mark
+		ioutil.WriteFile(path, []byte("0"), 0644)
+	}
+}
+
+func (poller Cgroup) Poll(tick time.Time) {
+	println("poll")
+
+	for _, cgroup := range poller.cgroups {
+		println(cgroup)
+
+		// I can't use the FileLineChannel here because I don't want
+		// to raise a fatal error if the cgroup doesn't exist yet.
+
+		cpuStat, err := filechan.FileLineChannel(CGROUPS_PATH + "/cpuacct/" + cgroup + "/cpuacct.stat")
+
+		if err == nil {
+			for line := range cpuStat {
+				poller.parsePercentCpu(line, tick)
+			}
+		}
+
+		poller.parseMaxMemory(cgroup, "user", "memory.max_usage_in_bytes", tick)
+		poller.parseMaxMemory(cgroup, "kernel", "memory.kmem.max_usage_in_bytes", tick)
+		poller.parseMaxMemory(cgroup, "kernel.tcp", "memory.kmem.tcp.max_usage_in_bytes", tick)
+	}
+}
+
+func (poller Cgroup) Name() string {
+	return "cgroup"
+}
+
+func (poller Cgroup) Exit() {}

--- a/cgroup_poller.go
+++ b/cgroup_poller.go
@@ -22,7 +22,6 @@ type Cgroup struct {
 }
 
 func NewCgroupPoller(measurements chan<- Measurement, config Config) Cgroup {
-	println("constructed")
 	return Cgroup{
 		measurements: measurements,
 		last:         make(map[string]uint64),
@@ -40,8 +39,6 @@ func sanitizeMetricName(name string) string {
 // calculates the delta from the last measurement, calculates the
 // average percentage of one CPU core used, and submits the data point.
 func (poller Cgroup) parsePercentCpu(line string, tick time.Time, cgroup string) {
-	println("cpu " + line)
-
 	fields := strings.Fields(line)
 
 	// "user" or "system"
@@ -64,8 +61,6 @@ func (poller Cgroup) parsePercentCpu(line string, tick time.Time, cgroup string)
 }
 
 func (poller Cgroup) parseMaxMemory(metric string, fileName string, tick time.Time, cgroup string) {
-	println("memory " + metric)
-
 	path := CGROUPS_PATH + "/memory/" + cgroup + "/" + fileName
 	data, err := ioutil.ReadFile(path)
 
@@ -79,11 +74,7 @@ func (poller Cgroup) parseMaxMemory(metric string, fileName string, tick time.Ti
 }
 
 func (poller Cgroup) Poll(tick time.Time) {
-	println("poll")
-
 	for _, cgroup := range poller.cgroups {
-		println(cgroup)
-
 		// I can't use the FileLineChannel here because I don't want
 		// to raise a fatal error if the cgroup doesn't exist yet.
 

--- a/cgroup_poller.go
+++ b/cgroup_poller.go
@@ -50,7 +50,8 @@ func (poller Cgroup) parsePercentCpu(line string, tick time.Time, cgroup string)
 	// absolute number of centiseconds of CPU time used
 	centis := Atouint64(fields[1])
 
-	last, exists := poller.last[metric]
+        key := cgroup + "." + metric
+	last, exists := poller.last[key]
 
 	if exists {
 		delta := centis - last
@@ -59,7 +60,7 @@ func (poller Cgroup) parsePercentCpu(line string, tick time.Time, cgroup string)
 		poller.measurements <- FloatGaugeMeasurement{tick, poller.Name(), []string{sanitizeMetricName(cgroup), "cpu", metric}, percent, Percent}
 	}
 
-	poller.last[metric] = centis
+	poller.last[key] = centis
 }
 
 func (poller Cgroup) parseMaxMemory(metric string, fileName string, tick time.Time, cgroup string) {

--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ const (
 	DEFAULT_REDIS_INFO               = "clients:connected_clients;memory:used_memory,used_memory_rss;stats:instantaneous_ops_per_sec;keyspace:db0.keys" // semi colon seperated section:keya,keyb list
 	DEFAULT_REDIS_URL                = "tcp://localhost:6379/0?timeout=10s&maxidle=1"
 	DEFAULT_META                     = false
+        DEFAULT_CGROUPS                  = ""
 )
 
 var (
@@ -88,6 +89,7 @@ type Config struct {
 	RedisUrl              *url.URL
 	RedisInfo             string
 	Meta                  bool
+        Cgroups               []string
 }
 
 func GetConfig() (config Config) {
@@ -128,6 +130,7 @@ func GetConfig() (config Config) {
 	config.RedisInfo = GetEnvWithDefault("SHH_REDIS_INFO", DEFAULT_REDIS_INFO)                                             // section:key1,key2;section2:key1,key2
 	config.NetworkTimeout = GetEnvWithDefaultDuration("NETWORK_TIMEOUT", DEFAULT_NETWORK_TIMEOUT)                          // The maximum time to wait for network requests to respond (for both dial and first header when applicable)
 	config.Meta = GetEnvWithDefaultBool("SHH_META", DEFAULT_META)                                                          // Should report meta measurements, such as batch sizes for outputters, etc.
+	config.Cgroups = GetEnvWithDefaultStrings("SHH_CGROUPS", DEFAULT_CGROUPS)                                              // Cgroups to report stats on
 
 	tmp := GetEnvWithDefault("SHH_DISK_FILTER", DEFAULT_DISK_FILTER)
 	config.DiskFilter = regexp.MustCompile(tmp)

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ const (
 	DEFAULT_REDIS_INFO               = "clients:connected_clients;memory:used_memory,used_memory_rss;stats:instantaneous_ops_per_sec;keyspace:db0.keys" // semi colon seperated section:keya,keyb list
 	DEFAULT_REDIS_URL                = "tcp://localhost:6379/0?timeout=10s&maxidle=1"
 	DEFAULT_META                     = false
-        DEFAULT_CGROUPS                  = ""
+	DEFAULT_CGROUPS                  = ""
 )
 
 var (
@@ -89,7 +89,7 @@ type Config struct {
 	RedisUrl              *url.URL
 	RedisInfo             string
 	Meta                  bool
-        Cgroups               []string
+	Cgroups               []string
 }
 
 func GetConfig() (config Config) {

--- a/pollers.go
+++ b/pollers.go
@@ -52,6 +52,8 @@ func NewMultiPoller(measurements chan<- Measurement, config Config) Multi {
 			mp.RegisterPoller(NewFolsomPoller(measurements, config))
 		case "redis":
 			mp.RegisterPoller(NewRedisPoller(measurements, config))
+		case "cgroup":
+			mp.RegisterPoller(NewCgroupPoller(measurements, config))
 
 		}
 	}


### PR DESCRIPTION
This is my first ever Go code, so please excuse any messes :)

This adds a poller that retrieves resource usage metrics for a list of cgroups.  It fetches information for the processes from two cgroup controllers: cpuacct and memory.

From cpuacct, it fetches user and system CPU time used by the group expressed as a percentage of a single core.  For example, a value of 125 would mean that process in the group used CPU time equivalent to one and one quarter of a CPU core for the entire polling interval.

From memory, it fetches the MAXIMUM memory usage of the group over the entire interval (the high-water mark).  It attempts to request that the kernel reset this value after each poll by writing a zero to the `memory.max_memory_usage` file in the group's directory.  This will only work if the SHH process has permissions to the file.  You can simply chown/chgrp the file appropriately to grant that access.  Failing to do this will result in this poller reporting only the historical maximum memory usage irrespective of the interval.

Three memory high-water marks are reported: "user", "kernel", and "tcp".  "user" is standard memory usage (RSS).  "Kernel" is kernel buffers and the like required by system calls made by processes in the group.  "tcp" is just kernel memory required for TCP sessions.  "Kernel" and "tcp" will always report 0 unless a respective memory limit for the cgroup has been set, due to limitations in the memory cgroup controller.

I've attempted to write this thing as best I can using Go and SHH idioms.  I opted for allowing cgroups to be specified as an environment variable rather than hardcoding the one we care about in an attempt to make this thing useful for anyone but us ;)  Please let me know if the code needs any tidying/restructuring and I'll do my best to accommodate.