### PR TITLE
Remove usage of legacy codon-buildpacks buildpack URL

### DIFF
--- a/.github/actions/builder/action.yml
+++ b/.github/actions/builder/action.yml
@@ -8,7 +8,7 @@ inputs:
   buildpack_url:
     description: 'the URL for the buildpack to use'
     required: false
-    default: 'https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/ruby.tgz'
+    default: 'https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/ruby.tgz'
   s3_bucket:
     description: 'S3 bucket to push the slug to'
     required: true

--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: ./.github/actions/builder
         with:
           stack: heroku-20
-          buildpack_url: https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/go.tgz
+          buildpack_url: https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/go.tgz
           aws_region: us-east-1
           s3_bucket: ${{ secrets.AWS_S3_BUCKET }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

New buildpack releases are currently backported to the legacy `codon-buildpacks` bucket from `buildpack-registry` by a sync job (so this PR has no change on functionality), however that job will be sunset soon, causing `codon-buildpacks` to become stale.

GUS-W-10034067.