### PR TITLE
Update Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: python -m http.server $PORT
+shh: bin/shh

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make & python -m SimpleHTTPServer $PORT
+web: make & python -m http.server $PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: make & python -m http.server $PORT
+web: python -m http.server $PORT


### PR DESCRIPTION
# Changes

- SimpleHTTPServer has been merged into http.server per python [docs](https://docs.python.org/2/library/simplehttpserver.html) so we should swap over. 
  - Currently, this repository does not have a `runtime.txt` file which is used to specify the python version per the heroku python buildpack [documentation](https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-python) so I believe it is safe to assume users will be running python3.
- we do not need to run `make all` during runtime when starting the shh app, this is already run during CI
- add the `shh` proc