### PR TITLE
Reduce metrics submission retries to one

### DIFF
--- a/librato_output.go
+++ b/librato_output.go
@@ -31,7 +31,7 @@ type LibratoPostBody struct {
 
 const (
 	LibratoBacklog         = 8 // No more than N pending batches in-flight
-	LibratoMaxAttempts     = 4 // Max attempts before dropping batch
+	LibratoMaxAttempts     = 1 // Max attempts before dropping batch
 	LibratoStartingBackoff = 500 * time.Millisecond
 )
 

--- a/librato_output.go
+++ b/librato_output.go
@@ -31,7 +31,7 @@ type LibratoPostBody struct {
 
 const (
 	LibratoBacklog         = 8 // No more than N pending batches in-flight
-	LibratoMaxAttempts     = 1 // Max attempts before dropping batch
+	LibratoMaxAttempts     = 2 // Max attempts before dropping batch
 	LibratoStartingBackoff = 500 * time.Millisecond
 )
 

--- a/librato_output_test.go
+++ b/librato_output_test.go
@@ -56,7 +56,7 @@ func (g *GrumpyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func TestLibrato_TimeToHeaderTimeout(t *testing.T) {
 	handler := &SleepyHandler{
 		Amt:     2 * time.Second,
-		ReqIncr: -600 * time.Millisecond,
+		ReqIncr: -2000 * time.Millisecond,
 	}
 	server := httptest.NewServer(handler)
 	defer server.Close()
@@ -74,13 +74,13 @@ func TestLibrato_TimeToHeaderTimeout(t *testing.T) {
 		t.Errorf("Request should not have errored with a sleepy handler")
 	}
 
-	if handler.times != 3 {
-		t.Error("Request should have been tried 3 times, instead it was tried: ", handler.times)
+	if handler.times != 2 {
+		t.Error("Request should have been tried 2 times, instead it was tried: ", handler.times)
 	}
 }
 
 func TestLibrato_ServerErrorBackoff(t *testing.T) {
-	handler := &GrumpyHandler{ResponseCodes: []int{503, 500, 200}}
+	handler := &GrumpyHandler{ResponseCodes: []int{503, 200}}
 	server := httptest.NewServer(handler)
 	defer server.Close()
 


### PR DESCRIPTION
During recent collector incidents we have observed that shh will retry sending its metrics up to 3 times when we return an error code.

https://ui.honeycomb.io/heroku/datasets/runtime-metrics-production/result/tjtycqjWKmZ
<img width="1521" alt="runtime-metrics-production Queries | Honeycomb io 2022-02-17 16-28-37" src="https://user-images.githubusercontent.com/175496/154594498-cb6b6512-4656-44c8-a7fd-46900bba7f9e.png">

This has a couple of issues:

- Extra load. In our last incident we have been unable to successfully process our current load of metrics. Having service send us more traffic makes it harder to recover.
- Extra metrics. The issues we are seeing are stemming from our Argus exporter, but the metrics *are* successfully being delivered to Honeycomb. This + the retries is resulting in the same metrics being delivered 4x to Honeycomb.

We are currently working to remedy both of these things, but in the meantime it would be helpful if `shh` would only attempt to retry once rather than 3 extra times.
