### PR TITLE
Ignore errant GPL license issues

### DIFF
--- a/.github/actions/builder/entrypoint.sh
+++ b/.github/actions/builder/entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+git config --global --add safe.directory /github/workspace
+
 if [[ $INPUT_USE_BUILDPACK == "true" ]]; then
     export STACK=$INPUT_STACK
     export GO_INSTALL_PACKAGE_SPEC="./cmd/*"

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:golang:github.com:heroku:shh:GPL-3.0':
+    - '*':
+        reason: Ignore errant GPL license issues
+        expires: 2022-09-07T19:56:11.000Z
+        created: 2022-06-09T19:56:14.016Z
+patch: {}


### PR DESCRIPTION
CI is failing due to Synk-reported GPL license issues, but we don't even have a GPL license here. Let's ignore this for now.

We also see failing CI due to this git issue:
```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
We add the above config line to the GHA builder entrypoint.