### PR TITLE
Build shh in 20.04 Container

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -4,8 +4,15 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:20.04
     steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/checkout@v2
       - uses: ./.github/actions/builder
         with:


### PR DESCRIPTION
Allows for [the deprecation of the Ubuntu 20.04 GitHub Action Runner hosts](https://github.com/actions/runner-images/issues/11101) while still building `shh` in the same way.